### PR TITLE
refactor: infrastructure changes

### DIFF
--- a/packages/infra/acm.tf
+++ b/packages/infra/acm.tf
@@ -1,8 +1,8 @@
 # SSL Certificate
 resource "aws_acm_certificate" "ssl_certificate" {
-  domain_name = var.domain_name
+  domain_name               = var.domain_name
   subject_alternative_names = ["*.${var.domain_name}"]
-  validation_method = "EMAIL"
+  validation_method         = "EMAIL"
 
   tags = var.common_tags
 

--- a/packages/infra/alb.tf
+++ b/packages/infra/alb.tf
@@ -49,15 +49,15 @@ resource "aws_alb_listener" "ptft_http_alb_listener" {
 }
 
 resource "aws_alb_listener" "ptft_https_alb_listener" {
-    load_balancer_arn = aws_lb.ptft_lb.id
-    port              = 443
-    protocol          = "HTTPS"
+  load_balancer_arn = aws_lb.ptft_lb.id
+  port              = 443
+  protocol          = "HTTPS"
 
-    ssl_policy        = "ELBSecurityPolicy-2016-08"
-    certificate_arn   = aws_acm_certificate_validation.cert_validation.certificate_arn
+  ssl_policy      = "ELBSecurityPolicy-2016-08"
+  certificate_arn = aws_acm_certificate_validation.cert_validation.certificate_arn
 
-    default_action {
-        target_group_arn = aws_alb_target_group.ptft_tg.id
-        type             = "forward"
-    }
+  default_action {
+    target_group_arn = aws_alb_target_group.ptft_tg.id
+    type             = "forward"
+  }
 }

--- a/packages/infra/cloudfront.tf
+++ b/packages/infra/cloudfront.tf
@@ -1,8 +1,8 @@
 # Cloudfront distribution for main s3 site.
 resource "aws_cloudfront_distribution" "www_s3_distribution" {
   origin {
-    domain_name = aws_s3_bucket.www_bucket.bucket_regional_domain_name
-    origin_id   = "S3-www.${var.bucket_name}"
+    domain_name              = aws_s3_bucket.www_bucket.bucket_regional_domain_name
+    origin_id                = "S3-www.${var.bucket_name}"
     origin_access_control_id = aws_cloudfront_origin_access_control.s3_oac.id
   }
 
@@ -33,7 +33,7 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
     }
 
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0 
+    min_ttl                = 0
     default_ttl            = 86400
     max_ttl                = 604800
     compress               = true

--- a/packages/infra/cloudfront.tf
+++ b/packages/infra/cloudfront.tf
@@ -1,33 +1,27 @@
 # Cloudfront distribution for main s3 site.
 resource "aws_cloudfront_distribution" "www_s3_distribution" {
   origin {
-    domain_name = aws_s3_bucket_website_configuration.www_bucket_website.website_endpoint
-    origin_id = "S3-www.${var.bucket_name}"
-
-    custom_origin_config {
-      http_port = 80
-      https_port = 443
-      origin_protocol_policy = "http-only"
-      origin_ssl_protocols = ["TLSv1", "TLSv1.1", "TLSv1.2"]
-    }
+    domain_name = aws_s3_bucket.www_bucket.bucket_regional_domain_name
+    origin_id   = "S3-www.${var.bucket_name}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.s3_oac.id
   }
 
-  enabled = true
-  is_ipv6_enabled = true
+  enabled             = true
+  is_ipv6_enabled     = true
   default_root_object = "index.html"
 
-  aliases = ["www.${var.domain_name}"]
+  aliases = ["www.${var.domain_name}", "${var.domain_name}"]
 
   custom_error_response {
     error_caching_min_ttl = 0
-    error_code = 404
-    response_code = 200
-    response_page_path = "/index.html"
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
   }
 
   default_cache_behavior {
-    allowed_methods = ["GET", "HEAD"]
-    cached_methods = ["GET", "HEAD"]
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
     target_origin_id = "S3-www.${var.bucket_name}"
 
     forwarded_values {
@@ -39,10 +33,10 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
     }
 
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl = 0 #this can be changed in the future
-    default_ttl = 0
-    max_ttl = 0
-    compress = true
+    min_ttl                = 0 #this can be changed in the future
+    default_ttl            = 0
+    max_ttl                = 0
+    compress               = true
   }
 
   restrictions {
@@ -52,64 +46,18 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
   }
 
   viewer_certificate {
-    acm_certificate_arn = aws_acm_certificate_validation.cert_validation.certificate_arn
-    ssl_support_method = "sni-only"
+    acm_certificate_arn      = aws_acm_certificate_validation.cert_validation.certificate_arn
+    ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.1_2016"
   }
 
   tags = var.common_tags
 }
 
-# Cloudfront S3 for redirect to www.
-resource "aws_cloudfront_distribution" "root_s3_distribution" {
-  origin {
-    domain_name = aws_s3_bucket_website_configuration.root_bucket_website.website_endpoint
-    origin_id = "S3-.${var.bucket_name}"
-    custom_origin_config {
-      http_port = 80
-      https_port = 443
-      origin_protocol_policy = "http-only"
-      origin_ssl_protocols = ["TLSv1", "TLSv1.1", "TLSv1.2"]
-    }
-  }
-
-  enabled = true
-  is_ipv6_enabled = true
-
-  aliases = [var.domain_name]
-
-  default_cache_behavior {
-    allowed_methods = ["GET", "HEAD"]
-    cached_methods = ["GET", "HEAD"]
-    target_origin_id = "S3-.${var.bucket_name}"
-
-    forwarded_values {
-      query_string = true
-
-      cookies {
-        forward = "none"
-      }
-
-      headers = ["Origin"]
-    }
-
-    viewer_protocol_policy = "allow-all"
-    min_ttl = 0
-    default_ttl = 86400
-    max_ttl = 31536000
-  }
-
-  restrictions {
-    geo_restriction {
-      restriction_type = "none"
-    }
-  }
-
-  viewer_certificate {
-    acm_certificate_arn = aws_acm_certificate_validation.cert_validation.certificate_arn
-    ssl_support_method = "sni-only"
-    minimum_protocol_version = "TLSv1.1_2016"
-  }
-
-  tags = var.common_tags
+resource "aws_cloudfront_origin_access_control" "s3_oac" {
+  name                              = "Main-S3-OAC"
+  description                       = "OAC for allow CDN access to S3"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
 }

--- a/packages/infra/cloudfront.tf
+++ b/packages/infra/cloudfront.tf
@@ -33,9 +33,9 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
     }
 
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0 #this can be changed in the future
-    default_ttl            = 0
-    max_ttl                = 0
+    min_ttl                = 0 
+    default_ttl            = 86400
+    max_ttl                = 604800
     compress               = true
   }
 

--- a/packages/infra/cloudfront.tf
+++ b/packages/infra/cloudfront.tf
@@ -2,7 +2,7 @@
 resource "aws_cloudfront_distribution" "www_s3_distribution" {
   origin {
     domain_name              = aws_s3_bucket.www_bucket.bucket_regional_domain_name
-    origin_id                = "S3-www.${var.bucket_name}"
+    origin_id                = "S3-${var.bucket_name}"
     origin_access_control_id = aws_cloudfront_origin_access_control.s3_oac.id
   }
 
@@ -22,7 +22,7 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "S3-www.${var.bucket_name}"
+    target_origin_id = "S3-${var.bucket_name}"
 
     forwarded_values {
       query_string = false

--- a/packages/infra/cloudwatch.tf
+++ b/packages/infra/cloudwatch.tf
@@ -1,10 +1,10 @@
 resource "aws_cloudwatch_log_group" "ptft_log_group" {
-  name = "awslogs-ptft-api"
+  name              = "awslogs-ptft-api"
   retention_in_days = 1
-  tags = var.common_tags
+  tags              = var.common_tags
 }
 
 resource "aws_cloudwatch_log_stream" "ptft_log_stream" {
-  name = "awslogs-ptft-api"
+  name           = "awslogs-ptft-api"
   log_group_name = aws_cloudwatch_log_group.ptft_log_group.name
 }

--- a/packages/infra/ecr.tf
+++ b/packages/infra/ecr.tf
@@ -1,5 +1,5 @@
 resource "aws_ecr_repository" "ptft_ecr" {
-  name = "ptft-ecr"
+  name                 = "ptft-ecr"
   image_tag_mutability = "MUTABLE"
 
   image_scanning_configuration {
@@ -14,10 +14,10 @@ resource "aws_ecr_lifecycle_policy" "ptft_ecr_policy" {
     rules = [{
       rulePriority = 1
       description  = "keep last 10 images"
-      action       = {
+      action = {
         type = "expire"
       }
-      selection     = {
+      selection = {
         tagStatus   = "any"
         countType   = "imageCountMoreThan"
         countNumber = 10

--- a/packages/infra/ecs_service.tf
+++ b/packages/infra/ecs_service.tf
@@ -12,13 +12,13 @@ resource "aws_ecs_service" "main" {
   network_configuration {
     subnets          = [aws_subnet.ptft_public_subnet_az1.id, aws_subnet.ptft_public_subnet_az2.id]
     assign_public_ip = true
-    security_groups = [ "${aws_security_group.ptft_ecs_sec_group.id}" ]
+    security_groups  = ["${aws_security_group.ptft_ecs_sec_group.id}"]
   }
 
   load_balancer {
     target_group_arn = aws_alb_target_group.ptft_tg.arn
-    container_name = "ptft_container"
-    container_port = 3001
+    container_name   = "ptft_container"
+    container_port   = 3001
   }
   # desired_count is ignored as it can change due to autoscaling policy
   lifecycle {

--- a/packages/infra/ecs_task.tf
+++ b/packages/infra/ecs_task.tf
@@ -7,15 +7,15 @@ resource "aws_ecs_task_definition" "ptft_ecs_task" {
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
   task_role_arn            = aws_iam_role.ecs_task_role.arn
   container_definitions = jsonencode([{
-    name        = "ptft_container"
-    image       = aws_ecr_repository.ptft_ecr.repository_url
-    essential   = true
+    name      = "ptft_container"
+    image     = aws_ecr_repository.ptft_ecr.repository_url
+    essential = true
     environment = [
-        {name = "NODE_ENV", value = "production"},
-        {name = "DATABASE_URL", value = var.db_url},
-        {name = "SIGNIN_KEY", value = var.signin_key},
-        {name = "JWT_SECRET", value = var.jwt_secret},
-        {name = "COOKIE_SECRET", value = var.cookie_secret}
+      { name = "NODE_ENV", value = "production" },
+      { name = "DATABASE_URL", value = var.db_url },
+      { name = "SIGNIN_KEY", value = var.signin_key },
+      { name = "JWT_SECRET", value = var.jwt_secret },
+      { name = "COOKIE_SECRET", value = var.cookie_secret }
     ]
     portMappings = [{
       protocol      = "tcp"
@@ -25,8 +25,8 @@ resource "aws_ecs_task_definition" "ptft_ecs_task" {
     logConfiguration = {
       logDriver = "awslogs"
       options = {
-        "awslogs-group" = "awslogs-ptft-api",
-        "awslogs-region" = "us-east-1",
+        "awslogs-group"         = "awslogs-ptft-api",
+        "awslogs-region"        = "us-east-1",
         "awslogs-stream-prefix" = "awslogs-ptft-api"
       }
     }

--- a/packages/infra/providers.tf
+++ b/packages/infra/providers.tf
@@ -17,4 +17,7 @@ terraform {
 
 provider "aws" {
   region = "us-east-1"
+  default_tags {
+    tags = var.common_tags
+  }
 }

--- a/packages/infra/providers.tf
+++ b/packages/infra/providers.tf
@@ -3,14 +3,14 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 4.27"
     }
   }
 
   backend "s3" {
     bucket = "protft-terraform"
-    key = "prod/terraform.tfstate"
+    key    = "prod/terraform.tfstate"
     region = "us-east-1"
   }
 }

--- a/packages/infra/rds.tf
+++ b/packages/infra/rds.tf
@@ -6,18 +6,18 @@ resource "aws_db_subnet_group" "ptft_db_subnet_group" {
 }
 
 resource "aws_db_instance" "ptft_db" {
-  allocated_storage = 20
+  allocated_storage       = 20
   backup_retention_period = 7
-  db_name = "ptft"
-  db_subnet_group_name = aws_db_subnet_group.ptft_db_subnet_group.name
-  engine = "postgres"
-  engine_version = "12"
-  instance_class = "db.t2.micro"
-  max_allocated_storage = 0
-  username = var.db_username
-  password = var.db_password
-  publicly_accessible = true
-  skip_final_snapshot = true
-  vpc_security_group_ids = ["${aws_security_group.ptft_rds_sec_group.id}"]
-  tags = var.common_tags
+  db_name                 = "ptft"
+  db_subnet_group_name    = aws_db_subnet_group.ptft_db_subnet_group.name
+  engine                  = "postgres"
+  engine_version          = "12"
+  instance_class          = "db.t2.micro"
+  max_allocated_storage   = 0
+  username                = var.db_username
+  password                = var.db_password
+  publicly_accessible     = true
+  skip_final_snapshot     = true
+  vpc_security_group_ids  = ["${aws_security_group.ptft_rds_sec_group.id}"]
+  tags                    = var.common_tags
 }

--- a/packages/infra/route53.tf
+++ b/packages/infra/route53.tf
@@ -5,36 +5,36 @@ resource "aws_route53_zone" "main" {
 
 resource "aws_route53_record" "root-a" {
   zone_id = aws_route53_zone.main.zone_id
-  name = var.domain_name
-  type = "A"
+  name    = var.domain_name
+  type    = "A"
 
   alias {
-    name = aws_cloudfront_distribution.www_s3_distribution.domain_name
-    zone_id = aws_cloudfront_distribution.www_s3_distribution.hosted_zone_id
+    name                   = aws_cloudfront_distribution.www_s3_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.www_s3_distribution.hosted_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "www-a" {
   zone_id = aws_route53_zone.main.zone_id
-  name = "www.${var.domain_name}"
-  type = "A"
+  name    = "www.${var.domain_name}"
+  type    = "A"
 
   alias {
-    name = aws_cloudfront_distribution.www_s3_distribution.domain_name
-    zone_id = aws_cloudfront_distribution.www_s3_distribution.hosted_zone_id
+    name                   = aws_cloudfront_distribution.www_s3_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.www_s3_distribution.hosted_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "ptft-api" {
   zone_id = aws_route53_zone.main.zone_id
-  name = "api.${var.domain_name}"
-  type = "A"
+  name    = "api.${var.domain_name}"
+  type    = "A"
 
   alias {
-    name = aws_lb.ptft_lb.dns_name
-    zone_id = aws_lb.ptft_lb.zone_id
+    name                   = aws_lb.ptft_lb.dns_name
+    zone_id                = aws_lb.ptft_lb.zone_id
     evaluate_target_health = false
   }
 }

--- a/packages/infra/route53.tf
+++ b/packages/infra/route53.tf
@@ -9,8 +9,8 @@ resource "aws_route53_record" "root-a" {
   type = "A"
 
   alias {
-    name = aws_cloudfront_distribution.root_s3_distribution.domain_name
-    zone_id = aws_cloudfront_distribution.root_s3_distribution.hosted_zone_id
+    name = aws_cloudfront_distribution.www_s3_distribution.domain_name
+    zone_id = aws_cloudfront_distribution.www_s3_distribution.hosted_zone_id
     evaluate_target_health = false
   }
 }

--- a/packages/infra/s3.tf
+++ b/packages/infra/s3.tf
@@ -72,6 +72,6 @@ resource "aws_s3_bucket_policy" "image_bucket_policy" {
 
 # S3 bucket for images
 resource "aws_s3_bucket" "image_bucket" {
-  bucket = var.image_bucket_name 
+  bucket = var.image_bucket_name
   tags   = var.common_tags
 }

--- a/packages/infra/s3.tf
+++ b/packages/infra/s3.tf
@@ -1,15 +1,27 @@
-resource "aws_s3_bucket_acl" "www_bucket_acl" {
-  bucket = aws_s3_bucket.www_bucket.id
-  acl    = "public-read"
+data "aws_iam_policy_document" "s3_main_policy" {
+  statement {
+    sid     = "AllowCDNAccess"
+    actions = ["s3:Get*"]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+    resources = ["${aws_s3_bucket.www_bucket.arn}/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.www_s3_distribution.arn]
+    }
+  }
 }
 
 resource "aws_s3_bucket_cors_configuration" "www_bucket_cors" {
   bucket = aws_s3_bucket.www_bucket.id
 
   cors_rule {
-    allowed_headers = ["Authorization", "Content-Length"]
-    allowed_methods = ["GET", "POST"]
-    allowed_origins = ["https://www.${var.domain_name}"]
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "POST", "HEAD"]
+    allowed_origins = ["*"]
     max_age_seconds = 3000
   }
 }
@@ -17,54 +29,36 @@ resource "aws_s3_bucket_cors_configuration" "www_bucket_cors" {
 resource "aws_s3_bucket_policy" "www_bucket_policy" {
   bucket = aws_s3_bucket.www_bucket.id
 
-  policy = templatefile("templates/s3-policy.json", { bucket = "www.${var.bucket_name}" })
+  policy = data.aws_iam_policy_document.s3_main_policy.json
 }
 
-resource "aws_s3_bucket_website_configuration" "www_bucket_website" {
-  bucket = aws_s3_bucket.www_bucket.id
-
-  index_document {
-    suffix = "index.html"
-  }
-
-  error_document {
-    key = "index.html"
-  }
+resource "aws_s3_bucket_public_access_block" "s3_block_public" {
+  bucket                  = aws_s3_bucket.www_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+  ignore_public_acls      = true
 }
 
 # S3 bucket for website.
 resource "aws_s3_bucket" "www_bucket" {
-  bucket = "www.${var.bucket_name}"
-  tags = var.common_tags
+  bucket = var.bucket_name
+  tags   = var.common_tags
 }
 
 # -------
-resource "aws_s3_bucket_acl" "root_bucket_acl" {
-  bucket = aws_s3_bucket.root_bucket.id
-  acl    = "public-read"
-}
-
-resource "aws_s3_bucket_policy" "root_bucket_policy" {
-  bucket = aws_s3_bucket.root_bucket.id
-
-  policy = templatefile("templates/s3-policy.json", { bucket = var.bucket_name })
-}
-
-resource "aws_s3_bucket_website_configuration" "root_bucket_website" {
-  bucket = aws_s3_bucket.root_bucket.id
-
-  redirect_all_requests_to {
-    host_name = "https://www.${var.domain_name}"
+data "aws_iam_policy_document" "s3_public_policy" {
+  statement {
+    sid       = "PublicReadGetObject"
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.image_bucket.arn}/*"]
+    principals {
+      identifiers = ["*"]
+      type        = "*"
+    }
   }
 }
-
-# S3 bucket for redirecting non-www to www.
-resource "aws_s3_bucket" "root_bucket" {
-  bucket = var.bucket_name
-  tags = var.common_tags
-}
-
-# -------
 
 resource "aws_s3_bucket_acl" "image_bucket_acl" {
   bucket = aws_s3_bucket.image_bucket.id
@@ -73,12 +67,11 @@ resource "aws_s3_bucket_acl" "image_bucket_acl" {
 
 resource "aws_s3_bucket_policy" "image_bucket_policy" {
   bucket = aws_s3_bucket.image_bucket.id
-
-  policy = templatefile("templates/s3-policy.json", { bucket = "protft-images" })
+  policy = data.aws_iam_policy_document.s3_public_policy.json
 }
 
 # S3 bucket for images
 resource "aws_s3_bucket" "image_bucket" {
-  bucket = "protft-images"
-  tags = var.common_tags
+  bucket = var.image_bucket_name 
+  tags   = var.common_tags
 }

--- a/packages/infra/sec_group.tf
+++ b/packages/infra/sec_group.tf
@@ -1,9 +1,9 @@
 resource "aws_security_group" "ptft_alb_sec_group" {
-  name = "ptft-alb-sec-group"
+  name   = "ptft-alb-sec-group"
   vpc_id = aws_vpc.ptft_vpc.id
 
   ingress {
-    protocol = "tcp"
+    protocol         = "tcp"
     from_port        = 80
     to_port          = 80
     cidr_blocks      = ["0.0.0.0/0"]
@@ -30,14 +30,14 @@ resource "aws_security_group" "ptft_alb_sec_group" {
 }
 
 resource "aws_security_group" "ptft_ecs_sec_group" {
-  name = "ptft-ecs-sec-group"
+  name   = "ptft-ecs-sec-group"
   vpc_id = aws_vpc.ptft_vpc.id
 
   ingress {
-    protocol         = "tcp"
-    from_port        = 3001
-    to_port          = 3001
-    security_groups  = [ aws_security_group.ptft_alb_sec_group.id ]
+    protocol        = "tcp"
+    from_port       = 3001
+    to_port         = 3001
+    security_groups = [aws_security_group.ptft_alb_sec_group.id]
   }
 
   egress {
@@ -52,7 +52,7 @@ resource "aws_security_group" "ptft_ecs_sec_group" {
 }
 
 resource "aws_security_group" "ptft_rds_sec_group" {
-  name = "ptft-rds-sec-group"
+  name   = "ptft-rds-sec-group"
   vpc_id = aws_vpc.ptft_vpc.id
 
   ingress {

--- a/packages/infra/sec_group.tf
+++ b/packages/infra/sec_group.tf
@@ -37,8 +37,7 @@ resource "aws_security_group" "ptft_ecs_sec_group" {
     protocol         = "tcp"
     from_port        = 3001
     to_port          = 3001
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    security_groups  = [ aws_security_group.ptft_alb_sec_group.id ]
   }
 
   egress {

--- a/packages/infra/variables.tf
+++ b/packages/infra/variables.tf
@@ -1,15 +1,15 @@
 variable "domain_name" {
-  type = string
+  type        = string
   description = "The domain name for the website."
 }
 
 variable "bucket_name" {
-  type = string
+  type        = string
   description = "Name of the root frontend bucket"
 }
 
 variable "image_bucket_name" {
-  type = string
+  type        = string
   description = "Name of bucket for serve images"
 }
 
@@ -18,31 +18,31 @@ variable "common_tags" {
 }
 
 variable "db_username" {
-  type = string
+  type        = string
   description = "DB username"
 }
 
 variable "db_password" {
-  type = string
+  type        = string
   description = "DB password"
 }
 
 variable "db_url" {
-  type = string
+  type        = string
   description = "DB URL"
 }
 
 variable "signin_key" {
-  type = string
+  type        = string
   description = "Key to create users"
 }
 
 variable "jwt_secret" {
-  type = string
+  type        = string
   description = "JWT encryption"
 }
 
 variable "cookie_secret" {
-  type = string
+  type        = string
   description = "Cookie encryption"
 }

--- a/packages/infra/variables.tf
+++ b/packages/infra/variables.tf
@@ -5,7 +5,12 @@ variable "domain_name" {
 
 variable "bucket_name" {
   type = string
-  description = "The name of the bucket without the www. prefix. Normally domain_name."
+  description = "Name of the root frontend bucket"
+}
+
+variable "image_bucket_name" {
+  type = string
+  description = "Name of bucket for serve images"
 }
 
 variable "common_tags" {

--- a/packages/infra/vpc.tf
+++ b/packages/infra/vpc.tf
@@ -1,47 +1,47 @@
 resource "aws_vpc" "ptft_vpc" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
-  tags = var.common_tags
+  tags                 = var.common_tags
 }
 
 resource "aws_internet_gateway" "ptft_internet_gateway" {
-    vpc_id = aws_vpc.ptft_vpc.id
-    tags = var.common_tags
+  vpc_id = aws_vpc.ptft_vpc.id
+  tags   = var.common_tags
 }
 
 resource "aws_subnet" "ptft_public_subnet_az1" {
-  vpc_id = aws_vpc.ptft_vpc.id
-  cidr_block = "10.0.16.0/20"
-  availability_zone = "us-east-1a"
+  vpc_id                  = aws_vpc.ptft_vpc.id
+  cidr_block              = "10.0.16.0/20"
+  availability_zone       = "us-east-1a"
   map_public_ip_on_launch = true
-  tags = var.common_tags
+  tags                    = var.common_tags
 }
 
 resource "aws_subnet" "ptft_public_subnet_az2" {
-  vpc_id = aws_vpc.ptft_vpc.id
-  cidr_block = "10.0.48.0/20"
-  availability_zone = "us-east-1b"
+  vpc_id                  = aws_vpc.ptft_vpc.id
+  cidr_block              = "10.0.48.0/20"
+  availability_zone       = "us-east-1b"
   map_public_ip_on_launch = true
-  tags = var.common_tags
+  tags                    = var.common_tags
 }
 
 resource "aws_route_table" "ptft_route_table" {
   vpc_id = aws_vpc.ptft_vpc.id
-  tags = var.common_tags
+  tags   = var.common_tags
 }
 
 resource "aws_route" "ptft_route" {
-  route_table_id = aws_route_table.ptft_route_table.id
+  route_table_id         = aws_route_table.ptft_route_table.id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id = aws_internet_gateway.ptft_internet_gateway.id
+  gateway_id             = aws_internet_gateway.ptft_internet_gateway.id
 }
 
 resource "aws_route_table_association" "ptft_route_table_assoc_az1" {
-  subnet_id = aws_subnet.ptft_public_subnet_az1.id
+  subnet_id      = aws_subnet.ptft_public_subnet_az1.id
   route_table_id = aws_route_table.ptft_route_table.id
 }
 
 resource "aws_route_table_association" "ptft_route_table_assoc_az2" {
-  subnet_id = aws_subnet.ptft_public_subnet_az2.id
+  subnet_id      = aws_subnet.ptft_public_subnet_az2.id
   route_table_id = aws_route_table.ptft_route_table.id
 }


### PR DESCRIPTION
This PR intents to clean infrastructure code, removing unnecessary resources and standardizing some resource names.
Also, enables cloudfront cache, setting one day (84600s) on default TTL.